### PR TITLE
Updated shortcode button styling

### DIFF
--- a/column-shortcodes.php
+++ b/column-shortcodes.php
@@ -260,7 +260,7 @@ class Codepress_Column_Shortcodes {
 	 */
 	public function add_shortcode_button( $page = null, $target = null ) {
 		?>
-			<a href="#TB_inline?width=640&amp;height=600&amp;inlineId=cpsh-wrap" class="thickbox" title="<?php _e( 'Select shortcode', CPSH_TEXTDOMAIN ); ?>" data-page="<?php echo $page; ?>" data-target="<?php echo $target; ?>">
+			<a href="#TB_inline?width=640&amp;height=600&amp;inlineId=cpsh-wrap" class="thickbox button" title="<?php _e( 'Select shortcode', CPSH_TEXTDOMAIN ); ?>" data-page="<?php echo $page; ?>" data-target="<?php echo $target; ?>">
 				<img src="<?php echo CPSH_URL . "/assets/images/shortcode.png";?>" alt="" />
 			</a>
 		<?php


### PR DESCRIPTION
Updated styling to be consistent with WordPress 3.8 UI.

![screen](https://f.cloud.github.com/assets/2430193/1764272/b1dcc8e8-6723-11e3-8425-a48cdfac891e.png)
